### PR TITLE
Remove unused entity_dependency module

### DIFF
--- a/make/development/jumpstart-academic.make
+++ b/make/development/jumpstart-academic.make
@@ -6,9 +6,6 @@ api = 2
 
 includes[] = "core/contrib.make"
 
-projects[entity_dependency][version] = "1.0-alpha1"
-projects[entity_dependency][subdir] = "contrib"
-
 ; Contrib Dev Versions
 ; Because Dev Versions can change we want to target the specific commit hash
 ; that this build works with.

--- a/make/development/jumpstart-personal.make
+++ b/make/development/jumpstart-personal.make
@@ -6,9 +6,6 @@ api = 2
 
 includes[] = "core/contrib.make"
 
-projects[entity_dependency][version] = "1.0-alpha1"
-projects[entity_dependency][subdir] = "contrib"
-
 ; Contrib Dev Versions
 ; Because Dev Versions can change we want to target the specific commit hash
 ; that this build works with.

--- a/make/development/jumpstart-plus.make
+++ b/make/development/jumpstart-plus.make
@@ -6,9 +6,6 @@ api = 2
 
 includes[] = "core/contrib.make"
 
-projects[entity_dependency][version] = "1.0-alpha1"
-projects[entity_dependency][subdir] = "contrib"
-
 ; Contrib Dev Versions
 ; Because Dev Versions can change we want to target the specific commit hash
 ; that this build works with.

--- a/make/development/jumpstart-vpsa.make
+++ b/make/development/jumpstart-vpsa.make
@@ -8,8 +8,6 @@ includes[] = "core/contrib.make"
 
 projects[context_http_headers][version] = "1.0"
 projects[context_http_headers][subdir] = "contrib"
-projects[entity_dependency][version] = "1.0-alpha1"
-projects[entity_dependency][subdir] = "contrib"
 projects[field_formatter_settings][version] = "1.1"
 projects[field_formatter_settings][subdir] = "contrib"
 projects[simple_field_formatter][version] = "2.0-beta2"

--- a/make/production/jumpstart-academic.make
+++ b/make/production/jumpstart-academic.make
@@ -6,9 +6,6 @@ api = 2
 
 includes[] = "core/contrib.make"
 
-projects[entity_dependency][version] = "1.0-alpha1"
-projects[entity_dependency][subdir] = "contrib"
-
 ; Contrib Dev Versions
 ; Because Dev Versions can change we want to target the specific commit hash
 ; that this build works with.

--- a/make/production/jumpstart-personal.make
+++ b/make/production/jumpstart-personal.make
@@ -8,8 +8,6 @@ includes[] = "core/contrib.make"
 
 projects[context_http_headers][version] = "1.0"
 projects[context_http_headers][subdir] = "contrib"
-projects[entity_dependency][version] = "1.0-alpha1"
-projects[entity_dependency][subdir] = "contrib"
 
 ; Contrib Dev Versions
 ; Because Dev Versions can change we want to target the specific commit hash

--- a/make/production/jumpstart-plus.make
+++ b/make/production/jumpstart-plus.make
@@ -6,9 +6,6 @@ api = 2
 
 includes[] = "core/contrib.make"
 
-projects[entity_dependency][version] = "1.0-alpha1"
-projects[entity_dependency][subdir] = "contrib"
-
 ; Contrib Dev Versions
 ; Because Dev Versions can change we want to target the specific commit hash
 ; that this build works with.

--- a/make/production/jumpstart-vpsa.make
+++ b/make/production/jumpstart-vpsa.make
@@ -8,8 +8,6 @@ includes[] = "core/contrib.make"
 
 projects[context_http_headers][version] = "1.0"
 projects[context_http_headers][subdir] = "contrib"
-projects[entity_dependency][version] = "1.0-alpha1"
-projects[entity_dependency][subdir] = "contrib"
 projects[field_formatter_settings][version] = "1.1"
 projects[field_formatter_settings][subdir] = "contrib"
 projects[simple_field_formatter][version] = "2.0-beta2"


### PR DESCRIPTION
@sherakama it does not look like we use this in any of our products. It looks like it was added in February, 2014, for some reason and never removed.
