### PR TITLE
soe-440: updated tag for stanford_sites_jumpstart_engineering

### DIFF
--- a/make/production/jumpstart-engineering.make
+++ b/make/production/jumpstart-engineering.make
@@ -44,7 +44,7 @@ projects[stanford_sites_jumpstart_academic][download][tag] = "7.x-4.5+4-dev"
 projects[stanford_sites_jumpstart_engineering][type] = "profile"
 projects[stanford_sites_jumpstart_engineering][download][type] = "git"
 projects[stanford_sites_jumpstart_engineering][download][url] = "git@github.com:SU-SOE/stanford_sites_jumpstart_engineering.git"
-projects[stanford_sites_jumpstart_engineering][download][tag] = "7.x-1.0"
+projects[stanford_sites_jumpstart_engineering][download][tag] = "7.x-1.0+1-dev"
 
 ; JSE Modules
 ; ------------------------------------------------------------------------------


### PR DESCRIPTION
@boznik : New JSE production tag for disabling related content.
