### PR TITLE
Remove field_collection duplicate patch

### DIFF
--- a/make/production/core/core-patches.make
+++ b/make/production/core/core-patches.make
@@ -3,6 +3,3 @@ api = 2
 
 ; https://www.drupal.org/node/2221307 | Patch allows for field groups to be rendered in ds custom block regions
 projects[ds][patch][] = "https://www.drupal.org/files/issues/ds_extras_field_group_not_rendered-2221307-18.patch"
-
-; https://www.drupal.org/node/2385985 | Deleting host entity causes save during deletion and triggers pathauto
-projects[field_collection][patch][] = "https://www.drupal.org/files/issues/field_collection-2385985-29.patch"


### PR DESCRIPTION
Now that this is pointing at 7.x-2.3 of Stanford-Drupal-Profile, this patch can be removed.
