### PR TITLE
7.x-5.0 release

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,10 +1,19 @@
-Version 7.x-1.x
----------------------------------------------------------------
-Initial Jumpstart and Jumpstart Academic deployment with install profiles.
+Stanford Jumpstart Deployer x.x-x.x, YYYY-MM-DD
+-----------------------------------------------
 
+Stanford Jumpstart Deployer 7.x-5.0, 2016-09-27
+-----------------------------------------------
+- Initial release of the 7.x-5.x branch
 
 Version 7.x-2.x
 ---------------------------------------------------------------
 
 February 2, 2014:
 - Update all features to features 2.x
+
+
+Version 7.x-1.x
+---------------------------------------------------------------
+Initial Jumpstart and Jumpstart Academic deployment with install profiles.
+
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #[Stanford Jumpstart Deployer](https://github.com/SU-SWS/stanford-jumpstart-deployer)
-##### Version: 7.x-5.x
+##### Version: 7.x-5.0
 
 Maintainers: [jbickar](https://github.com/jbickar), [sherakama](https://github.com/sherakama)
 


### PR DESCRIPTION
We had discussed various strategies for making releases of this product. This may not need to be `5.0`, but we should at least tag it _something_.
