### PR TITLE
HSDO-493: Update stanford_jumpstart to 5.2 

### DIFF
--- a/production/product/jumpstart-academic/stanford.make
+++ b/production/product/jumpstart-academic/stanford.make
@@ -116,7 +116,7 @@ projects[stanford_jumpstart][type] = "module"
 projects[stanford_jumpstart][subdir] = "stanford"
 projects[stanford_jumpstart][download][type] = "git"
 projects[stanford_jumpstart][download][url] = "git@github.com:SU-SWS/stanford_jumpstart.git"
-projects[stanford_jumpstart][download][tag] = "7.x-5.1"
+projects[stanford_jumpstart][download][tag] = "7.x-5.2"
 
 projects[stanford_jumpstart_home][type] = "module"
 projects[stanford_jumpstart_home][subdir] = "stanford"

--- a/production/product/jumpstart-lab/stanford.make
+++ b/production/product/jumpstart-lab/stanford.make
@@ -111,7 +111,7 @@ projects[stanford_jumpstart][type] = "module"
 projects[stanford_jumpstart][subdir] = "stanford"
 projects[stanford_jumpstart][download][type] = "git"
 projects[stanford_jumpstart][download][url] = "git@github.com:SU-SWS/stanford_jumpstart.git"
-projects[stanford_jumpstart][download][tag] = "7.x-5.1"
+projects[stanford_jumpstart][download][tag] = "7.x-5.2"
 
 projects[stanford_jumpstart_home][type] = "module"
 projects[stanford_jumpstart_home][subdir] = "stanford"

--- a/production/product/jumpstart-plus/stanford.make
+++ b/production/product/jumpstart-plus/stanford.make
@@ -119,7 +119,7 @@ projects[stanford_jumpstart][type] = "module"
 projects[stanford_jumpstart][subdir] = "stanford"
 projects[stanford_jumpstart][download][type] = "git"
 projects[stanford_jumpstart][download][url] = "git@github.com:SU-SWS/stanford_jumpstart.git"
-projects[stanford_jumpstart][download][tag] = "7.x-5.1"
+projects[stanford_jumpstart][download][tag] = "7.x-5.2"
 
 projects[stanford_jumpstart_home][type] = "module"
 projects[stanford_jumpstart_home][subdir] = "stanford"

--- a/production/product/jumpstart/stanford.make
+++ b/production/product/jumpstart/stanford.make
@@ -122,7 +122,7 @@ projects[stanford_jumpstart][type] = "module"
 projects[stanford_jumpstart][subdir] = "stanford"
 projects[stanford_jumpstart][download][type] = "git"
 projects[stanford_jumpstart][download][url] = "git@github.com:SU-SWS/stanford_jumpstart.git"
-projects[stanford_jumpstart][download][tag] = "7.x-5.1"
+projects[stanford_jumpstart][download][tag] = "7.x-5.2"
 
 projects[stanford_landing_page][type] = "module"
 projects[stanford_landing_page][subdir] = "stanford"


### PR DESCRIPTION
# Ready for Review

The 5.2 tag as it has new wysiwyg settings.

**TO TEST**
- Build a JSV site with this branch
- Go to a node/edit page with a body field (stanford_page)
- Select content_editor text format
- Ensure there is a "Breakout Box Dark" option in the styles drop down
- Edit some text and apply the "Breakout Box Dark" style option
- Ensure styles in wyswiyg look ok
- Save the node
- Ensure the styles in the front end look ok

Screenshot:
![screen shot 2016-09-29 at 2 26 03 pm](https://cloud.githubusercontent.com/assets/550602/18973073/ae091682-8650-11e6-9b0d-ada5065cbf03.png)
