### PR TITLE
Updated all products to use stanford_manage_content 3.5

### DIFF
--- a/production/product/jumpstart-academic/stanford.make
+++ b/production/product/jumpstart-academic/stanford.make
@@ -128,7 +128,7 @@ projects[stanford_manage_content][type] = "module"
 projects[stanford_manage_content][subdir] = "stanford"
 projects[stanford_manage_content][download][type] = "git"
 projects[stanford_manage_content][download][url] = "git@github.com:SU-SWS/stanford_manage_content.git"
-projects[stanford_manage_content][download][tag] = "7.x-3.4"
+projects[stanford_manage_content][download][tag] = "7.x-3.5"
 
 projects[stanford_news][type] = "module"
 projects[stanford_news][subdir] = "stanford"

--- a/production/product/jumpstart-engineering/stanford.make
+++ b/production/product/jumpstart-engineering/stanford.make
@@ -132,7 +132,7 @@ projects[stanford_landing_page][download][url] = "git@github.com:SU-SWS/stanford
 projects[stanford_landing_page][subdir] = "stanford"
 projects[stanford_landing_page][type] = "module"
 
-projects[stanford_manage_content][download][tag] = "7.x-3.4"
+projects[stanford_manage_content][download][tag] = "7.x-3.5"
 projects[stanford_manage_content][download][type] = "git"
 projects[stanford_manage_content][download][url] = "git@github.com:SU-SWS/stanford_manage_content.git"
 projects[stanford_manage_content][subdir] = "stanford"

--- a/production/product/jumpstart-lab/stanford.make
+++ b/production/product/jumpstart-lab/stanford.make
@@ -146,7 +146,7 @@ projects[stanford_manage_content][type] = "module"
 projects[stanford_manage_content][subdir] = "stanford"
 projects[stanford_manage_content][download][type] = "git"
 projects[stanford_manage_content][download][url] = "git@github.com:SU-SWS/stanford_manage_content.git"
-projects[stanford_manage_content][download][tag] = "7.x-3.4"
+projects[stanford_manage_content][download][tag] = "7.x-3.5"
 
 projects[stanford_news][type] = "module"
 projects[stanford_news][subdir] = "stanford"

--- a/production/product/jumpstart-plus/stanford.make
+++ b/production/product/jumpstart-plus/stanford.make
@@ -146,7 +146,7 @@ projects[stanford_manage_content][type] = "module"
 projects[stanford_manage_content][subdir] = "stanford"
 projects[stanford_manage_content][download][type] = "git"
 projects[stanford_manage_content][download][url] = "git@github.com:SU-SWS/stanford_manage_content.git"
-projects[stanford_manage_content][download][tag] = "7.x-3.4"
+projects[stanford_manage_content][download][tag] = "7.x-3.5"
 
 projects[stanford_news][type] = "module"
 projects[stanford_news][subdir] = "stanford"

--- a/production/product/jumpstart/stanford.make
+++ b/production/product/jumpstart/stanford.make
@@ -140,7 +140,7 @@ projects[stanford_manage_content][type] = "module"
 projects[stanford_manage_content][subdir] = "stanford"
 projects[stanford_manage_content][download][type] = "git"
 projects[stanford_manage_content][download][url] = "git@github.com:SU-SWS/stanford_manage_content.git"
-projects[stanford_manage_content][download][tag] = "7.x-3.4"
+projects[stanford_manage_content][download][tag] = "7.x-3.5"
 
 projects[stanford_jumpstart_home][type] = "module"
 projects[stanford_jumpstart_home][subdir] = "stanford"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updates all products to use stanford_manage_content 3.5 which includes the fix for the VBO delete wrong entities bug.

# Needed By (Date)
- March 15th

# Urgency
- Lesser now that VBO is being updated.

# Steps to Test

1. Let Travis / Behat do the heavy lifting on this one.

# Affected Projects or Products
- All production releases of all of our products

# Associated Issues and/or People
- John / Kellie / Everyone on sites.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)