### PR TITLE
SOE-1696: Update landing page version

### DIFF
--- a/production/product/jumpstart-engineering/stanford.make
+++ b/production/product/jumpstart-engineering/stanford.make
@@ -126,7 +126,7 @@ projects[stanford_jumpstart_academic][download][url] = "git@github.com:SU-SWS/st
 projects[stanford_jumpstart_academic][subdir] = "stanford"
 projects[stanford_jumpstart_academic][type] = "module"
 
-projects[stanford_landing_page][download][tag] = "7.x-1.5"
+projects[stanford_landing_page][download][tag] = "7.x-1.6-beta1"
 projects[stanford_landing_page][download][type] = "git"
 projects[stanford_landing_page][download][url] = "git@github.com:SU-SWS/stanford_landing_page.git"
 projects[stanford_landing_page][subdir] = "stanford"


### PR DESCRIPTION
# NOT READY
- Dependent on https://github.com/SU-SOE/stanford_sites_jumpstart_engineering/pull/51

# Summary
-  Update the landing page version to get the Behat tests to pass

# Needed By (Date)
- Thursday, 3/14

# Urgency
- Not urgent

# Steps to Test

1. Build a new version of JSE
2. Run behat tests for landing page: 
$ ../../bin/behat -p your-site -s dev features/stanford_landing_page
3. Verify it passes

# Affected Projects or Products
- JSE product

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-1696
- Other PRs: https://github.com/SU-SWS/linky_clicky/pull/149
- Without this PR, two Behat tests for landing page fail


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)