### PR TITLE
SOE-1695: updated tag for stanford_sites_jumpstart_engineering

### DIFF
--- a/production/product/jumpstart-engineering/profiles.make
+++ b/production/product/jumpstart-engineering/profiles.make
@@ -6,7 +6,7 @@ api = 2
 
 ; JSE Profiles
 
-projects[stanford_sites_jumpstart_engineering][download][tag] = "7.x-5.2+2-dev"
+projects[stanford_sites_jumpstart_engineering][download][tag] = "7.x-5.3+7-dev"
 projects[stanford_sites_jumpstart_engineering][download][type] = "git"
 projects[stanford_sites_jumpstart_engineering][download][url] = "git@github.com:SU-SOE/stanford_sites_jumpstart_engineering.git"
 projects[stanford_sites_jumpstart_engineering][type] = "profile"


### PR DESCRIPTION
# READY
@boznik It's ready! I tested locally. 
# Summary
-  Enable gallery modules

# Needed By (Date)
Before it falls into the cracks

# Urgency
- Not urgent

# Steps to Test

1. Build a new version of JSE
2. Verify that stanford_gallery_administration and stanford_gallery_administration have been enabled.

# Affected Projects or Products
- JSE product

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-1695
- Without this PR, two Behat tests for gallery fail


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)