### PR TITLE
Update module stanford_sites_helper-7.x-1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
     - BEHAT_TAG="deploy"
     - DEPLOYER_BRANCH=""
     - DRUPAL_PROFILE_BRANCH=""
-    - CLICKY_BRANCH=""
+    - CLICKY_BRANCH="uat20170505-updates"
     - SCRIPTS_BRANCH=""
   matrix:
     # Jumpstart Labs

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
     - BEHAT_TAG="deploy"
     - DEPLOYER_BRANCH=""
     - DRUPAL_PROFILE_BRANCH=""
-    - CLICKY_BRANCH="uat20170505-updates"
+    - CLICKY_BRANCH=""
     - SCRIPTS_BRANCH=""
   matrix:
     # Jumpstart Labs

--- a/production/environment/sites.make
+++ b/production/environment/sites.make
@@ -11,7 +11,7 @@ projects[stanford_sites_helper][subdir] = "stanford"
 projects[stanford_sites_helper][type] = "module"
 projects[stanford_sites_helper][download][type] = "git"
 projects[stanford_sites_helper][download][url] = "git@github.com:SU-SWS/stanford_sites_helper.git"
-projects[stanford_sites_helper][download][tag] = "7.x-1.6"
+projects[stanford_sites_helper][download][tag] = "7.x-1.7"
 
 projects[webauth][subdir] = "stanford"
 projects[webauth][type] = "module"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This new version of stanford_sites_helper, changes HelpSU links to ServiceNow.  We are deploying 1.7 as part of the upgrades scheduled for 05/30-06/01, but still needed to update the deployer.

# Needed By (Date)
- While there is no deadline, new sites deployed with the old version of stanford_sites_helper will misdirect users looking for support.

# Urgency
- Not super urgent, but if all tests pass, the sooner we can merge the better.

# Steps to Test
- Travis.yml has been updated to test against this branch: https://github.com/SU-SWS/linky_clicky/pull/159, which checks for 1.7 links to ServiceNow.

# Affected Projects or Products
- Updates to the deployer as part of the uat20170505/stable20170525 upgrade process: https://stanfordits.atlassian.net/browse/DEVOPS-16